### PR TITLE
fix: project secret was not set

### DIFF
--- a/internal/mixpanel/project.go
+++ b/internal/mixpanel/project.go
@@ -61,6 +61,7 @@ func (c *Client) GetProject(id int64) (*Project, error) {
 		Timezone: response.Results.Timezone,
 		ApiKey:   response.Results.ApiKey,
 		Token:    response.Results.Token,
+		Secret:   response.Results.Secret,
 	}
 
 	if response.Results.Domain == "eu.mixpanel.com" {


### PR DESCRIPTION
The property existed but it was an empty string, I tested and it's now set properly and accessible

![image](https://github.com/user-attachments/assets/7f805f0f-d170-4b82-a9cc-1b68f5fddf19)
